### PR TITLE
画面幅が小さい時に画面上部にタイトルを表示した

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,12 +2,18 @@
 import HeroImage from "../components/HeroImage.astro";
 import Hamburger from "./Hamburger.astro";
 import Navigation from "./Navigation.astro";
+
+interface Props {
+  pageTitle: string;
+}
+
+const { pageTitle } = Astro.props;
 ---
 
 <header class="mb-5">
   <nav class="flex flex-col gap-4">
     <Hamburger />
     <HeroImage />
-    <Navigation />
+    <Navigation pageTitle={pageTitle} />
   </nav>
 </header>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,11 +2,17 @@
 import NavigationBar from "./NavigationBar.astro";
 import NavigationDrawer from "./NavigationDrawer.astro";
 
+interface Props {
+  pageTitle: string;
+}
+
 export interface NavLink {
   href: string;
   label: string;
   icon: string;
 }
+
+const { pageTitle } = Astro.props;
 
 const navLinks = [
   { href: "/", label: "TOP", icon: "material-symbols:home" },
@@ -21,10 +27,6 @@ const navLinks = [
 ];
 ---
 
-<div
-  id="nav-overlay"
-  class="invisible opacity-0 fixed inset-0 bg-black/50 z-40"
->
-</div>
+<div id="nav-overlay" class="invisible opacity-0 fixed inset-0 bg-black/50 z-40"></div>
 <NavigationDrawer navLinks={navLinks} />
-<NavigationBar navLinks={navLinks} />
+<NavigationBar navLinks={navLinks} pageTitle={pageTitle} />

--- a/src/components/NavigationBar.astro
+++ b/src/components/NavigationBar.astro
@@ -1,32 +1,22 @@
 ---
-import { Icon } from "astro-icon/components";
-import clsx from "clsx";
 import type { NavLink } from "./Navigation.astro";
+import PageLinksBar from "./PageLinksBar.astro";
+import PageTitleBar from "./PageTitleBar.astro";
 
 interface Props {
   navLinks: NavLink[];
+  pageTitle: string;
 }
 
-const { navLinks }: Props = Astro.props;
-
-const currentPath = Astro.url.pathname;
+const { navLinks, pageTitle } = Astro.props;
 ---
 
-<div
-  class="hidden md:flex md:space-x-3 md:items-center md:bg-blue-700 md:px-4 md:py-1"
->
-  {
-    navLinks.map((link) => (
-      <a
-        href={link.href}
-        class={clsx(
-          "font-bold text-white hover:bg-white hover:text-blue-700 rounded px-3 py-1 transition flex items-center gap-1",
-          currentPath === link.href && "text-2xl underline",
-        )}
-      >
-        <Icon name={link.icon} class="text-2xl" />
-        {link.label}
-      </a>
-    ))
-  }
+<div class="bg-blue-700 px-4">
+  <div class="hidden md:block">
+    <PageLinksBar navLinks={navLinks} />
+  </div>
+
+  <div class="md:hidden">
+    <PageTitleBar pageTitle={pageTitle} />
+  </div>
 </div>

--- a/src/components/PageLinksBar.astro
+++ b/src/components/PageLinksBar.astro
@@ -1,0 +1,29 @@
+---
+import { Icon } from "astro-icon/components";
+import clsx from "clsx";
+import type { NavLink } from "./Navigation.astro";
+
+interface Props {
+  navLinks: NavLink[];
+}
+
+const { navLinks } = Astro.props;
+const currentPath = Astro.url.pathname;
+---
+
+<div class="flex items-center space-x-3 py-1">
+  {
+    navLinks.map((link) => (
+      <a
+        href={link.href}
+        class={clsx(
+          "font-bold text-white hover:bg-white hover:text-blue-700 rounded px-3 py-1 transition flex items-center gap-1",
+          currentPath === link.href && "text-2xl underline",
+        )}
+      >
+        <Icon name={link.icon} class="text-2xl" />
+        {link.label}
+      </a>
+    ))
+  }
+</div>

--- a/src/components/PageTitleBar.astro
+++ b/src/components/PageTitleBar.astro
@@ -1,0 +1,11 @@
+---
+interface Props {
+  pageTitle: string;
+}
+
+const { pageTitle } = Astro.props;
+---
+
+<div class="h-[3.0rem]">
+  <h1 class="font-bold text-white text-2xl py-2">{pageTitle}</h1>
+</div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const { pageTitle } = Astro.props;
     <title>{pageTitle}</title>
   </head>
   <body class="bg-gray-50 px-4 flex flex-col">
-    <Header />
+    <Header pageTitle={pageTitle} />
     <slot />
     <Footer />
     <script>


### PR DESCRIPTION
## Issue

- Close #12

## 目的

画面幅が小さい時にナビゲーションバーがなくなることによってレイアウトが急激に変化することを防ぐため

## やったこと

- ページのタイトルだけをバーに表示するコンポーネントを追加
- 画面幅によってバーに表示する内容を変化させる

## 動作確認

画面幅が大きい時

<img width="953" height="934" alt="image" src="https://github.com/user-attachments/assets/bcdee5d6-210e-496d-91df-e972fb35411f" />


画面幅が小さい時

<img width="550" height="934" alt="image" src="https://github.com/user-attachments/assets/2afd5346-2ac2-4251-b3f9-01ede44ecbd7" />

