### PR TITLE
ナビゲーションと内容の横幅を揃えた

### DIFF
--- a/src/components/NavigationBar.astro
+++ b/src/components/NavigationBar.astro
@@ -11,12 +11,12 @@ interface Props {
 const { navLinks, pageTitle } = Astro.props;
 ---
 
-<div class="bg-blue-700 px-3">
-  <div class="hidden md:block max-w-5xl mx-auto px-3 lg:px-9">
+<div class="bg-blue-700">
+  <div class="hidden md:block max-w-5xl mx-auto">
     <PageLinksBar navLinks={navLinks} />
   </div>
 
-  <div class="md:hidden max-w-5xl mx-auto px-3 lg:px-9">
+  <div class="md:hidden max-w-5xl mx-auto px-3">
     <PageTitleBar pageTitle={pageTitle} />
   </div>
 </div>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -34,7 +34,9 @@ const { page } = Astro.props;
     )
   }
 
-  <div class="w-10 h-10 flex items-center justify-center border border-gray-800 bg-gray-800 text白">
+  <div
+    class="w-10 h-10 flex items-center justify-center border border-gray-800 bg-gray-800 text-white"
+  >
     {page.currentPage}
   </div>
 

--- a/src/pages/news/[page].astro
+++ b/src/pages/news/[page].astro
@@ -12,14 +12,14 @@ export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
     return b.data.date.getTime() - a.data.date.getTime();
   });
 
-  return paginate(sortedNews, { pageSize: 15 });
+  return paginate(sortedNews, { pageSize: 20 });
 }
 
 const { page } = Astro.props;
 ---
 
 <BaseLayout pageTitle="ニュース一覧">
-  <div class="container mx-auto px-4 py-8">
+  <div class="max-w-5xl mx-auto px-4 py-8">
     <h1 class="font-semibold text-xl pl-2 border-b-2 border-l-8 border-solid border-black mb-3">
       NEWS
     </h1>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -5,7 +5,7 @@ const pageTitle = "研究内容";
 ---
 
 <BaseLayout pageTitle={pageTitle}>
-  <div class="w-full max-w-[60rem] mx-auto px-4">
+  <div class="w-full max-w-5xl mx-auto">
     <p class="mb-8 sm:text-lg">
       計算知能最適化、機械学習、機械学習に関連した最適化、群ロボット、実問題への応用、などに関する研究を行っています。
     </p>


### PR DESCRIPTION
## Issue

- Close #33 
- Close #32 

## 目的

横幅を揃えることで統一感を出すため

## 動作確認

トップページのみを掲載

| デスクトップ | モバイル | 
| ------------ | -------- | 
|       <img width="1096" height="934" alt="image" src="https://github.com/user-attachments/assets/2cf282fc-8dc1-4c81-a0e3-4f0fc0de65e3" /> |     <img width="391" height="848" alt="image" src="https://github.com/user-attachments/assets/d22e2e61-b4f3-41c1-94a8-ce0ac2a38e7c" /> | 
